### PR TITLE
Pick up Oauth state from cookie if one exists

### DIFF
--- a/src/customs/middleware/oauth2.clj
+++ b/src/customs/middleware/oauth2.clj
@@ -52,7 +52,7 @@
 
 (defn- launch-handler [profile]
   (fn [{:keys [session] :or {session {}} :as request}]
-    (let [state (random-state)]
+    (let [state (or (::state session) (random-state))]
       (-> (response/redirect (make-authorize-uri profile request state))
           (assoc :session (assoc session ::state state))))))
 
@@ -110,7 +110,7 @@
         (-> (resp/redirect landing-uri)
             (assoc :session (-> session
                                 (assoc ::access-tokens (access-token-fn))
-                                (dissoc ::state))))
+                                (assoc ::state nil))))
         (error-handler request)))))
 
 


### PR DESCRIPTION
## Context
State mismatch on authentication currently does nothing, but just leaves the user on an browser error page. 

This change makes the client pick up an already existing state - if there is one - and re-use it. 

This means if a user would enter the login flow through a new tab, the same state will be used, and the login will succeed in both tabs.

Also adding query parameters to be passed along to the login page. The change was first introduced in https://github.com/starcity-properties/customs/pull/2 but that PR was closed.