### PR TITLE
CDM-63 Update JWT signing to sign specified claims

### DIFF
--- a/src/customs/auth/jwt.clj
+++ b/src/customs/auth/jwt.clj
@@ -70,10 +70,12 @@
   :max-age  - Interval in seconds the token is valid from when it's issued.
               Optional (default 3600 secs)."
   [account secret options]
-  (jwt/sign (claims (:db/id account)
-                    (:account/role account)
-                    options)
-            secret))
+  (jwt/sign
+    (claims (:db/id account)
+      (or (:role options)
+        (:account/role account))
+      options)
+    secret))
 
 
 (defn unsign

--- a/src/customs/auth/jwt.clj
+++ b/src/customs/auth/jwt.clj
@@ -60,7 +60,7 @@
 
 (defn sign
   "Produce a signed JWT given an account, secret and options.
-  1 arity: sign the supplied `claims` with the `secret`.
+  2 arity: sign the supplied `use-claims` with the `secret`.
 
   Options:
   :iss      - URI of the issuer. Required.
@@ -73,11 +73,7 @@
   ([use-claims secret]
    (jwt/sign use-claims secret))
   ([account secret options]
-   (jwt/sign
-     (claims (:db/id account)
-       (:account/role account)
-       options)
-     secret)))
+   (jwt/sign (claims (:db/id account) (:account/role account) options) secret)))
 
 
 (defn unsign

--- a/src/customs/auth/jwt.clj
+++ b/src/customs/auth/jwt.clj
@@ -7,7 +7,7 @@
             [buddy.auth.backends :as backends]
             [customs.access :as access]))
 
-(defn- claims
+(defn claims
   "Returns a map with our JWT claims, given the eid and role of the account:
 
   Registered claims:
@@ -60,6 +60,7 @@
 
 (defn sign
   "Produce a signed JWT given an account, secret and options.
+  1 arity: sign the supplied `claims` with the `secret`.
 
   Options:
   :iss      - URI of the issuer. Required.
@@ -69,13 +70,14 @@
   :exp      - Unix time in seconds after which the JWT must NOT be accepted.
   :max-age  - Interval in seconds the token is valid from when it's issued.
               Optional (default 3600 secs)."
-  [account secret options]
-  (jwt/sign
-    (claims (:db/id account)
-      (or (:role options)
-        (:account/role account))
-      options)
-    secret))
+  ([use-claims secret]
+   (jwt/sign use-claims secret))
+  ([account secret options]
+   (jwt/sign
+     (claims (:db/id account)
+       (:account/role account)
+       options)
+     secret)))
 
 
 (defn unsign


### PR DESCRIPTION
## Context
Adding functionality to specify a role when signing a JWT. Used when authenticating with client credentials, where the subject of the token is not a user account but an oauth client.

Related: https://github.com/starcity-properties/lobby/pull/41

## Testing
Unit tests added in https://github.com/starcity-properties/lobby/pull/41