### PR TITLE
CDM-480 Land user on url they wanted to go after login.

### DIFF
--- a/src/customs/middleware/oauth2.clj
+++ b/src/customs/middleware/oauth2.clj
@@ -109,7 +109,7 @@
           error-handler          (:state-mismatch-handler profile state-mismatch-handler)
           landing-uri            (or landing-uri (get-in request [:params landing-uri-key]))]
       (if state-matches?
-        (-> (resp/redirect landing-uri)
+        (-> (resp/redirect (or landing-uri "/"))
           (assoc :session (-> session
                             (assoc ::access-tokens (access-token-fn))
                             (assoc ::state nil))))


### PR DESCRIPTION
## Context
We want to provide the functionality in our applications to direct users to where they intended to go after they've logged in.

Example:
1. I navigate to my.starcity.com/properties
2. I'm unauthorized, and redirected to login.
3. After successful login, I want to be taken straight to my.starcity.com/properties.

Right now we'll land everyone on `/`, but this is adding the support for the above scenario by redirecting the user to the URL specified in the param for `:landing-uri-key`.

**Supporting PR for**
- https://github.com/starcity-properties/odin/pull/376

JIRA: https://starcity.atlassian.net/browse/CDM-480

## Testing
- Running the system manually and try the above flow.
- Added a small test case to carry over query params.