### PR TITLE
OPS-138 | Handle authentication with Auth0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,15 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [com.datomic/datomic-free "0.9.5544"]
-                 [buddy "2.0.0"]
+                 [buddy/buddy-core "1.6.0"]
+                 [buddy/buddy-sign "3.1.0"]
+                 [buddy/buddy-hashers "1.4.0"]
+                 [buddy/buddy-auth "2.2.0"]
                  [starcity/toolbelt-datomic "0.1.0"]
                  [com.cemerick/url "0.1.1"]
 
                  [cheshire "5.8.0"]
+                 [clj-http "3.10.0"]
                  [clj-time "0.14.4"]
                  [ring/ring-core "1.6.3"]]
 

--- a/src/customs/auth/auth0.clj
+++ b/src/customs/auth/auth0.clj
@@ -1,0 +1,95 @@
+(ns customs.auth.auth0
+  (:require
+   [buddy.auth.backends :as backends]
+   [buddy.core.keys :as buddy.keys]
+   [buddy.sign.jws :as jws]
+   [clj-http.client :as client]))
+
+
+(def ^:private weighted-legacy-roles
+  {"legacy:applicant"  0
+   "legacy:onboarding" 1
+   "legacy:member"     2
+   "legacy:admin"      3})
+
+
+(defn payload->role [payload]
+  (letfn [(-most-permissive [permissions]
+            (ffirst (sort-by val > (select-keys weighted-legacy-roles permissions))))
+          (-permission->role [permission]
+            (keyword "account.role" (second (clojure.string/split permission #":" 2))))]
+    (if-some [scope (not-empty (:scope payload))]
+      (-permission->role scope)
+      (-permission->role (-most-permissive (:permissions payload))))))
+
+
+(defn sub->db-id [sub]
+  (Long. (second (clojure.string/split sub #"\|" 2))))
+
+
+(defn- retrieve-jwks [jwks-uri]
+  (let [pkeys (try
+                ;; TODO (waiyaki): TTL cache pkeys by their :kid
+                (:keys (:body (client/get jwks-uri {:as :json})))
+                (catch Exception e
+                  (throw
+                    (ex-info (or (.getMessage e)
+                               "Error retrieving signing keys from JWKS endpoint")
+                      {:jwks-uri jwks-uri
+                       :message  "Error retrieving signing keys from JWKS endpoint"}))))]
+    (if (> (count pkeys) 0)
+      pkeys
+      (throw (ex-info "JWKS endpoint did not contain any keys"
+               {:jwks-uri jwks-uri
+                :message  "JWKS endpoint did not contain any keys."})))))
+
+
+(defn- find-rsa-signing-key [token keys]
+  (let [kid         (:kid (jws/decode-header token))
+        signing-key (some->> keys
+                      (filter #(and
+                                 (= "RSA" (:kty %))
+                                 (= "sig" (:use %))
+                                 (or
+                                   (some? (:n %))
+                                   (some? (:e %))
+                                   (not (empty? (:x5c %))))
+                                 (= kid (:kid %))))
+                      first
+                      buddy.keys/jwk->public-key)]
+    (if (some? signing-key)
+      signing-key
+      (throw (ex-info "JSON Web Key Set contains no RSA signing keys."
+               {:message "JWKS contains no RSA signing keys."
+                :jwks    keys})))))
+
+
+(defn backend [jwks-uri token {:keys [options] :as opts}]
+  (let [pkey (find-rsa-signing-key token (retrieve-jwks jwks-uri))]
+    (backends/jws (merge opts
+                    {:secret pkey
+                     :options (merge options {:alg :rs256})}))))
+
+
+(comment
+  (require
+    '[buddy.auth.backends :as backends]
+    '[buddy.sign.jwt :as jwt]
+    '[customs.access :as access])
+
+  (def url "https://starcity-dev.auth0.com/.well-known/jwks.json")
+  (def auth0-keys (:body (client/get url {:as :json})))
+  (def pkey (buddy.keys/jwk->public-key (first (:keys auth0-keys))))
+
+  ;; get any JWT token from auth0 at the starcity-dev domain
+  (def t "")
+
+  (def auth-backend (backend url t {:token-name           "Bearer"
+                                    :unauthorized-handler access/default-unauthorized}))
+
+  ;; Flip :skip-validation to test with expired tokens
+  (jwt/unsign t pkey {:alg             :rs256
+                      :skip-validation false})
+
+  (def auth-data (buddy.auth.protocols/-authenticate auth-backend {} t))
+  )

--- a/src/customs/auth/auth0.clj
+++ b/src/customs/auth/auth0.clj
@@ -25,7 +25,7 @@
 
 
 (defn entity-id [payload]
-  (Long. (second (clojure.string/split (:sub payload) #"\|" 2))))
+  (java.util.UUID/fromString (second (clojure.string/split (:sub payload) #"\|" 2))))
 
 
 (defn retrieve-jwks [jwks-uri]

--- a/src/customs/auth/jwt.clj
+++ b/src/customs/auth/jwt.clj
@@ -151,8 +151,7 @@
             (when-some [auth-data (protocols/-authenticate backend request data)]
               ;; The JWT has been validated, so we'll transform the standard JWT fields to a map
               ;; representing an account entity in our system
-              {:db/id        (auth0/sub->db-id (:sub auth-data))
-               ;; Keywords become strings when signed, so make it a keyword again.
+              {:db/id        (auth0/entity-id auth-data)
                :account/role (auth0/payload->role auth-data)}))
           (catch Exception e
             ;; Unable to authenticate via Auth0

--- a/src/customs/auth/jwt.clj
+++ b/src/customs/auth/jwt.clj
@@ -152,7 +152,7 @@
               ;; representing an account entity in our system
               (if (= "client-credentials" (:gty auth-data))
                 (assoc auth-data :account/role (auth0/payload->role auth-data))
-                {:db/id        (auth0/entity-id auth-data)
+                {:account/id   (auth0/entity-id auth-data)
                  :account/role (auth0/payload->role auth-data)})))
           (catch Exception e
             ;; Unable to authenticate via Auth0


### PR DESCRIPTION
### Context
We need to support authenticating with Auth0. 

This PR adds a JWS backend to support validating JWT tokens issued by Auth0. Auth0 can issue tokens signed both symmetrically using `HS256` and asymmetrically using `RS256`. The introduced backend only handles tokens signed with `RS256`.
