### PR TITLE
Fix role resolution with just openid scopes

### DIFF
--- a/src/customs/auth/auth0.clj
+++ b/src/customs/auth/auth0.clj
@@ -19,9 +19,10 @@
             (ffirst (sort-by val > (select-keys weighted-legacy-roles permissions))))
           (-permission->role [permission]
             (keyword "account.role" (second (str/split permission #":" 2))))]
-    (if-some [scopes (some-> (:scope payload) not-empty (str/split #" "))]
-      (-permission->role (-most-permissive scopes))
-      (-permission->role (-most-permissive (:permissions payload))))))
+    (let [scopes (some-> (:scope payload) not-empty (str/split #" "))]
+      (if-some [legacy-scopes (seq (filter #(str/starts-with? % "legacy:") scopes))]
+        (-permission->role (-most-permissive legacy-scopes))
+        (-permission->role (-most-permissive (:permissions payload)))))))
 
 
 (defn entity-id [payload]


### PR DESCRIPTION
## Context

Auth0 may issue a token whose payload has a `scope`, but the scope may not contain any of the legacy roles.

While prioritising the permissions requested in the scope, this PR falls back to always using the permissions array when legacy roles are not available in the scope.

<img width="728" alt="Screenshot 2020-05-11 at 18 46 29" src="https://user-images.githubusercontent.com/17286899/81581741-d0d2de00-93b7-11ea-933c-d1e2d655458e.png">
